### PR TITLE
Various fixes to build_c4z.py

### DIFF
--- a/dp3/build_c4z.py
+++ b/dp3/build_c4z.py
@@ -251,6 +251,12 @@ def compressFileList(c4z, dir, root, files, zip, encryptedLua):
 
         return squishedLua
 
+    except ModuleNotFoundError as err:
+        Log("Error: %s" % err)
+        if err.name == 'M2Crypto':
+            Log("M2Crypto is required to encrypt the driver (https://gitlab.com/m2crypto/m2crypto).")
+        raise
+
     # Just swallow the exception.
     except:
         pass

--- a/dp3/build_c4z.py
+++ b/dp3/build_c4z.py
@@ -157,6 +157,7 @@ def compressLists(c4z, dirIn, dirsIn, filesIn, encryptedLua=None):
 def compressFileList(c4z, dir, root, files, zip, encryptedLua):
     tempDir = None
     try:
+        squishedLua = None
         tempDir = tempfile.mkdtemp()
         tRoot = root = os.path.normpath(root)
         for file in files:

--- a/dp3/build_c4z.py
+++ b/dp3/build_c4z.py
@@ -258,10 +258,6 @@ def compressFileList(c4z, dir, root, files, zip, encryptedLua):
             Log("M2Crypto is required to encrypt the driver (https://gitlab.com/m2crypto/m2crypto).")
         raise
 
-    # Just swallow the exception.
-    except:
-        pass
-
     finally:
         if tempDir:
             shutil.rmtree(tempDir)


### PR DESCRIPTION
This pull request has the following fixes/improvements:

- Catch the 'ModuleNotFoundError' and report it if M2Crypto is not installed. I tried to use driverpackager on a new machine and was lazy to read the requirements and did not install M2Crypto. However, packager did not report any error and exited successfully, but the driver was invalid. Therefore, report ModuleNotFoundError error and exit.
- Do not ignore any other exception, for the same reasons as above.
- Fix a reference before assignment error