### PR TITLE
Stop execution when PrepackageCommand returns an error

### DIFF
--- a/dp3/driverpackager.py
+++ b/dp3/driverpackager.py
@@ -179,7 +179,7 @@ class DriverPackager(object):
                 osCommand = prepackageCmd.text.replace("\\", os.path.sep)
                 osCommand = osCommand.replace("/", os.path.sep)
                 if (os.system(osCommand) != 0):
-                    print("Failed to execute prepackage command.")
+                    raise Exception("Failed to execute prepackage command.")
 
         items = xmlRoot.find('Items')
         if items == None:


### PR DESCRIPTION
The `driverpackager` should stop when an error occurs in the `PrepackageCommand`, otherwise we might get an invalid build.
As an example, I was using `luacheck` as a `PrepackageCommand` and even though it found errors the build continued.