### PR TITLE
Fix for adding directory which contains lua files which get squished.

### DIFF
--- a/dp3/build_c4z.py
+++ b/dp3/build_c4z.py
@@ -129,15 +129,16 @@ def compressLists(c4z, dirIn, dirsIn, filesIn, encryptedLua=None):
                         c4zDir = c4zDir + root[indexRoot:]
 
                     # Replace file entries with structure value entries
+                    fileList = []
                     for i, f in enumerate(files):
-                        del files[i]
                         if squishLua_ == False:
-                            files.insert(i, {'c4zDir': c4zDir, 'name': f})
+                            fileList.insert(i, {'c4zDir': c4zDir, 'name': f})
                         else:
                             if f not in GetSquishySource(dirIn):
-                                files.insert(i, {'c4zDir': c4zDir, 'name': f})
+                                fileList.insert(i, {'c4zDir': c4zDir, 'name': f})
 
-                    compressFileList(c4z, dirIn, root, files,
+
+                    compressFileList(c4z, dirIn, root, fileList,
                                      zip, encryptedLua)
                     if dir["recurse"] == str('false').lower():
                         break


### PR DESCRIPTION
file list would end up with strings, when it should be a list of dictionaries.
it happens in the case where you have a lua file in a directory getting added to the c4z, but that lua file is in the list of squished files, so it gets removed from list, but nothing gets added, and this stuffs up the enumeration of the list.