### PR TITLE
Removed xml declaration from output driver.xml

### DIFF
--- a/dp3/driverpackager.py
+++ b/dp3/driverpackager.py
@@ -479,7 +479,7 @@ class DriverPackager(object):
                     raise Exception("empty <version> tag")
                 driverVersion.text = self.driver_version
 
-            xmlTree.write(self.bytes_io, encoding='UTF-8', xml_declaration=True)
+            xmlTree.write(self.bytes_io, encoding='UTF-8', xml_declaration=False)
         except Exception as ex:
             self.Log(ex)
             raise Exception("Unable to update driver.xml")


### PR DESCRIPTION
Composer couldn't parse the driver.xml when the declaration was present
![declaration](https://user-images.githubusercontent.com/78961046/135848904-4a6be459-fa48-4de1-8cd6-b0f43a9280db.png)
![no_parse](https://user-images.githubusercontent.com/78961046/135848938-a601c57c-2aa3-475f-8b8e-d6acc7e4b2e4.png)
![no_declaration](https://user-images.githubusercontent.com/78961046/135848977-969781df-5add-4a30-9bcf-93cee4587c99.png)
![parse](https://user-images.githubusercontent.com/78961046/135848990-bf131d91-8acd-4af5-8819-6f1fdd9491c1.png)

